### PR TITLE
Removing deprecated 'skip_cleanup', defaults now to 'cleanup: false'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,13 +44,11 @@ deploy:
       local_dir: files-to-gh-pages
       target_branch: gh-pages
       verbose: true
-      skip_cleanup: true
       keep_history: true
       on:
         branch: master
     # Run deployment script on vm
     - provider: script
-      skip_cleanup: true
       script: cd $TRAVIS_BUILD_DIR; ssh smithlu7@129.194.69.131 'bash ' < deploy_vm.sh
       on:
         branch: master


### PR DESCRIPTION
Removing deprecated 'skip_cleanup' tag in .travis.yml